### PR TITLE
Loading groups

### DIFF
--- a/.github/workflows/loading-groups.yml
+++ b/.github/workflows/loading-groups.yml
@@ -6,6 +6,7 @@ jobs:
    build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         smalltalk: [ Pharo64-8.0, Pharo64-7.0 ]
         load-spec: [ core, api-client, service-discovery, deployment ]

--- a/.github/workflows/loading-groups.yml
+++ b/.github/workflows/loading-groups.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         smalltalk: [ Pharo64-8.0, Pharo64-7.0 ]
-        load-spec: [ .loading.core.ston .loading.api-client.ston .loading.service-discovery.ston .loading.deployment.ston ]
+        load-spec: [ .loading.core.ston, .loading.api-client.ston, .loading.service-discovery.ston, .loading.deployment.ston ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/loading-groups.yml
+++ b/.github/workflows/loading-groups.yml
@@ -8,15 +8,15 @@ jobs:
     strategy:
       matrix:
         smalltalk: [ Pharo64-8.0, Pharo64-7.0 ]
-        load-spec: [ .loading.core.ston, .loading.api-client.ston, .loading.service-discovery.ston, .loading.deployment.ston ]
-    name: ${{ matrix.smalltalk }}
+        load-spec: [ core, api-client, service-discovery, deployment ]
+    name: ${{ matrix.smalltalk }} + ${{ matrix.load-spec }}
     steps:
       - uses: actions/checkout@v2
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-version: ${{ matrix.smalltalk }}
       - name: Load group in image
-        run: smalltalkci -s ${{ matrix.smalltalk }} ${{ matrix.load-spec }}
+        run: smalltalkci -s ${{ matrix.smalltalk }} .loading.${{ matrix.load-spec }}.ston
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 15

--- a/.github/workflows/loading-groups.yml
+++ b/.github/workflows/loading-groups.yml
@@ -1,0 +1,22 @@
+name: Group loading check
+
+on: [push,pull_request]
+
+jobs:
+   build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        smalltalk: [ Pharo64-8.0, Pharo64-7.0 ]
+        load-spec: [ .loading.core.ston .loading.api-client.ston .loading.service-discovery.ston .loading.deployment.ston ]
+    name: ${{ matrix.smalltalk }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hpi-swa/setup-smalltalkCI@v1
+        with:
+          smalltalk-version: ${{ matrix.smalltalk }}
+      - name: Load group in image
+        run: smalltalkci -s ${{ matrix.smalltalk }} ${{ matrix.load-spec }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 15

--- a/.loading.api-client.ston
+++ b/.loading.api-client.ston
@@ -1,0 +1,13 @@
+SmalltalkCISpec {
+  #loading : [
+    SCIMetacelloLoadSpec {
+      #baseline : 'Superluminal',
+      #directory : 'source',
+      #load : [ 'API Client' ],
+      #platforms : [  #pharo ]
+    }
+  ],
+  #testing : {
+    #failOnZeroTests : false
+  }
+}

--- a/.loading.core.ston
+++ b/.loading.core.ston
@@ -1,0 +1,13 @@
+SmalltalkCISpec {
+  #loading : [
+    SCIMetacelloLoadSpec {
+      #baseline : 'Superluminal',
+      #directory : 'source',
+      #load : [ 'Core' ],
+      #platforms : [  #pharo ]
+    }
+  ],
+  #testing : {
+    #failOnZeroTests : false
+  }
+}

--- a/.loading.deployment.ston
+++ b/.loading.deployment.ston
@@ -1,0 +1,13 @@
+\SmalltalkCISpec {
+  #loading : [
+    SCIMetacelloLoadSpec {
+      #baseline : 'Superluminal',
+      #directory : 'source',
+      #load : [ 'Deployment' ],
+      #platforms : [  #pharo ]
+    }
+  ],
+  #testing : {
+    #failOnZeroTests : false
+  }
+}

--- a/.loading.deployment.ston
+++ b/.loading.deployment.ston
@@ -1,4 +1,4 @@
-\SmalltalkCISpec {
+SmalltalkCISpec {
   #loading : [
     SCIMetacelloLoadSpec {
       #baseline : 'Superluminal',

--- a/.loading.service-discovery.ston
+++ b/.loading.service-discovery.ston
@@ -1,0 +1,13 @@
+SmalltalkCISpec {
+  #loading : [
+    SCIMetacelloLoadSpec {
+      #baseline : 'Superluminal',
+      #directory : 'source',
+      #load : [ 'Service Discovery' ],
+      #platforms : [  #pharo ]
+    }
+  ],
+  #testing : {
+    #failOnZeroTests : false
+  }
+}

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,12 +1,24 @@
 # Installation
 
+## Provided groups
+
+- `Core` will load the packages providing HTTPRequest building blocks to be used in a deployed application
+- `API Client` will load the packages providing API client building blocks to be used in a deployed application
+- `Service Discovery` will load the packages providing service discovery strategies to be used in a deployed application
+- `Deployment` will load all the packages needed in a deployed application (Basically Core + API Client + Service Discovery)
+- `Tests` will load the test cases
+- `Dependent-SUnit-Extensions` will load the extensions to the SUnit framework
+- `Tools` will load the extensions to the SUnit framework and development tools (inspector and spotter extensions)
+- `CI` is the group loaded in the continuous integration setup
+- `Development` will load all the needed packages to develop and contribute to the project
+
 ## Basic Installation
 
 You can load **Superluminal** evaluating:
 ```smalltalk
 Metacello new
 	baseline: 'Superluminal';
-	repository: 'github://ba-st/Superluminal:release-candidate/source';
+	repository: 'github://ba-st/Superluminal:release-candidate';
 	load.
 ```
 >  Change `release-candidate` to some released version if you want a pinned version
@@ -21,7 +33,7 @@ setUpDependencies: spec
 	spec
 		baseline: 'Superluminal'
 			with: [ spec
-				repository: 'github://ba-st/Superluminal:v{XX}/source';
+				repository: 'github://ba-st/Superluminal:v{XX}';
 				loads: #('Deployment') ];
 		import: 'Superluminal'.
 ```
@@ -36,12 +48,3 @@ baseline: spec
 		do: [ self setUpDependencies: spec.
 			spec package: 'My-Package' with: [ spec requires: #('Superluminal') ] ]
 ```
-
-## Provided groups
-
-- `Deployment` will load all the packages needed in a deployed application
-- `Tests` will load the test cases
-- `Dependent-SUnit-Extensions` will load the extensions to the SUnit framework
-- `Tools` will load the extensions to the SUnit framework and development tools (inspector and spotter extensions)
-- `CI` is the group loaded in the continuous integration setup
-- `Development` will load all the needed packages to develop and contribute to the project

--- a/source/BaselineOfSuperluminal/BaselineOfSuperluminal.class.st
+++ b/source/BaselineOfSuperluminal/BaselineOfSuperluminal.class.st
@@ -57,42 +57,37 @@ BaselineOfSuperluminal >> setUpDependencies: spec [
 BaselineOfSuperluminal >> setUpPackages: spec [
 
 	spec
-		package: 'Superluminal-Model'
-		with: [ spec requires: #( 'Hyperspace-Deployment' 'NeoJSON-Core' ) ];
+		package: 'Superluminal-Model' with: [ spec requires: #('Hyperspace-Deployment' 'NeoJSON-Core') ];
+		group: 'Core' with: 'Superluminal-Model';
 		group: 'Deployment' with: 'Superluminal-Model'.
-
 	spec
 		package: 'Superluminal-RESTfulAPI'
-		with: [ spec requires: #( 'Superluminal-Model' 'ObjectPool-Core' ) ];
+			with: [ spec requires: #('Superluminal-Model' 'ObjectPool-Core') ];
+		group: 'API Client' with: 'Superluminal-RESTfulAPI';
 		group: 'Deployment' with: 'Superluminal-RESTfulAPI'.
-
 	spec
-		package: 'Superluminal-Service-Discovery';
+		package: 'Superluminal-Service-Discovery' with: [ spec requires: 'Superluminal-Model' ];
+		group: 'Service Discovery' with: 'Superluminal-Service-Discovery';
 		group: 'Deployment' with: 'Superluminal-Service-Discovery'.
-
 	spec
 		package: 'Superluminal-Service-Discovery-Examples'
-		with: [ spec requires: #( 'Deployment' 'Launchpad-Deployment' ) ];
+			with: [ spec requires: #('Deployment' 'Launchpad-Deployment') ];
 		group: 'Examples' with: 'Superluminal-Service-Discovery-Examples'.
-
 	spec
 		package: 'Superluminal-Model-Tests'
-		with: [ spec requires: #( 'Superluminal-Model' 'Hyperspace-SUnit' ) ];
+			with: [ spec requires: #('Superluminal-Model' 'Hyperspace-SUnit') ];
 		group: 'Tests' with: 'Superluminal-Model-Tests'.
-
 	spec
 		package: 'Superluminal-RESTfulAPI-Tests'
-		with: [ spec requires: #( 'Superluminal-RESTfulAPI' 'Hyperspace-SUnit' ) ];
+			with: [ spec requires: #('Superluminal-RESTfulAPI' 'Hyperspace-SUnit') ];
 		group: 'Tests' with: 'Superluminal-RESTfulAPI-Tests'.
-
 	spec
 		package: 'Superluminal-Service-Discovery-Tests'
-		with: [ 
-			spec requires: #( 'Superluminal-Service-Discovery' 'Hyperspace-SUnit' 'Teapot-Deployment' ) ];
+			with:
+				[ spec requires: #('Superluminal-Service-Discovery' 'Hyperspace-SUnit' 'Teapot-Deployment') ];
 		group: 'Tests' with: 'Superluminal-Service-Discovery-Tests'.
-
 	spec
 		package: 'Superluminal-Service-Discovery-Examples-Tests'
-		with: [ spec requires: 'Superluminal-Service-Discovery-Examples' ];
+			with: [ spec requires: 'Superluminal-Service-Discovery-Examples' ];
 		group: 'Tests' with: 'Superluminal-Service-Discovery-Examples-Tests'
 ]


### PR DESCRIPTION
Add the following loading groups that can be used for deployment:
- Core : Will only load the HTTPRequest abstractions
- API Client : Will load the building blocks for creating API Clients
- Service Discovery : Will load the available service discovery strategies
- Deployment : Combines the previous 3 groups

Also add GitHub actions to test the loading of each group