### PR TITLE
Minor tweaks

### DIFF
--- a/source/Superluminal-Model-Tests/HttpRequestTest.class.st
+++ b/source/Superluminal-Model-Tests/HttpRequestTest.class.st
@@ -219,7 +219,7 @@ HttpRequestTest >> testGetWithToken [
 			self
 				assertUrl: json url equals: self httpbinLocation;
 				assert: json method equals: 'GET';
-				assertJson: json headers at: #Authorization equals: 'Bearer ''xxx'''
+				assertJson: json headers at: #Authorization equals: 'Bearer xxx'
 			]
 ]
 

--- a/source/Superluminal-Model-Tests/SetHeaderCommandTest.class.st
+++ b/source/Superluminal-Model-Tests/SetHeaderCommandTest.class.st
@@ -13,7 +13,7 @@ SetHeaderCommandTest >> testApplyOn [
 	command := SetHeaderCommand settingAuthorizationToBearerToken:  'token'.
 	command applyOn: httpClient.
 
-	self assert: ( httpClient request headers at: #Authorization ) equals: 'Bearer ''token'''
+	self assert: ( httpClient request headers at: #Authorization ) equals: 'Bearer token'
 ]
 
 { #category : #tests }

--- a/source/Superluminal-Model/SetHeaderCommand.class.st
+++ b/source/Superluminal-Model/SetHeaderCommand.class.st
@@ -41,7 +41,7 @@ SetHeaderCommand class >> settingAuthorizationTo: anAuthorizationDirective [
 { #category : #'instance creation' }
 SetHeaderCommand class >> settingAuthorizationToBearerToken: token [
 
-	^ self settingAuthorizationTo: ( #'Bearer <1p>' expandMacrosWith: token )
+	^ self settingAuthorizationTo: ( #'Bearer <1s>' expandMacrosWith: token asString)
 ]
 
 { #category : #applying }

--- a/source/Superluminal-RESTfulAPI/RESTfulAPIClient.class.st
+++ b/source/Superluminal-RESTfulAPI/RESTfulAPIClient.class.st
@@ -229,7 +229,8 @@ RESTfulAPIClient >> postAt: aLocation configuredBy: aRequestBuildingBlock withSu
 				do: [ :httpClient | response := httpRequest applyOn: httpClient ].
 			response isSuccess
 				ifTrue: [ expiringCache clearResourceAt: aLocation.
-					response isCreated then: [ self tryToCacheContentsOf: response basedOn: response location ].
+					( response isCreated and: [ response hasLocation ] )
+						then: [ self tryToCacheContentsOf: response basedOn: response location ].
 					aBlock value: response contents
 					]
 				ifFalse: [ ( HTTPClientError code: response code ) signal: ( self clientErrorMessageFrom: response ) ]


### PR DESCRIPTION
Fix bearer token command to correctly configure a token already provided as a String

Improve RESTfulAPIClient post methods to take into account that some bad implementations don't produce the `Location` header for 201/Created responses.

Requires ba-st/Hyperspace#46 to be merged.